### PR TITLE
adding a keymap to toggle the minimap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ The setup method accepts an optional table as an argument with the following opt
 
 The default keybindings are as follows:
 ```
-<leader>mm - open the minimap
+<leader>mo - open the minimap
 <leader>mc - close the minimap
 <leader>mf - focus/unfocus the minimap
+<leader>mm - toggle the minimap
 ```
 
 To create your own keybindings, you can use the functions:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To create your own keybindings, you can use the functions:
 ```lua
 codewindow.open_minimap()
 codewindow.close_minimap()
+codewindow.toggle_minimap()
 codewindow.toggle_focus()
 ```
 
@@ -71,7 +72,6 @@ I tested the performance on the `lua/codewindow/highlight.lua` file in the repos
 
 ## TODO
 
-- Toggle function - this is an oversight I'm too tired to fix right now, but shouldn't take long
 - Help pages for the functions
 - Faster updates - theoretically only the lines that were edited need updating
 - Git support - I have a free column on the right reserved for it

--- a/lua/codewindow.lua
+++ b/lua/codewindow.lua
@@ -32,10 +32,19 @@ function M.toggle_focus()
   end
 end
 
+function M.toggle_minimap()
+  if minimap_win.is_minimap_open() then
+    M.close_minimap()
+  else
+    M.open_minimap()
+  end
+end
+
 function M.apply_default_keybinds()
-  vim.keymap.set('n', '<leader>mm', M.open_minimap)
+  vim.keymap.set('n', '<leader>mo', M.open_minimap)
   vim.keymap.set('n', '<leader>mf', M.toggle_focus)
   vim.keymap.set('n', '<leader>mc', M.close_minimap)
+  vim.keymap.set('n', '<leader>mm', M.toggle_minimap)
 end
 
 function M.setup(config)


### PR DESCRIPTION
To open an close the minimap remembering or having the habit of two different keymap is not a good idea in my opinion.

Changes:
```
<leader>mo - open the minimap
<leader>mc - close the minimap
<leader>mf - focus/unfocus the minimap
<leader>mm - toggle the minimap
```