### PR TITLE
feat: .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Builtin support for Editorconfig was recently [merged into the master branch](https://github.com/neovim/neovim/pull/21633) (see: `:help editorconfig`). It was also bundled with the latest release of NeoVim (0.9)

Because of that, it's likely almost everyone will have this enabled already, and as such this makes it easy to contribute to this project.