### PR TITLE
Chore: clean the codebase a little - reduce overhead and underlocalization

### DIFF
--- a/lua/codewindow.lua
+++ b/lua/codewindow.lua
@@ -4,13 +4,16 @@ local minimap_txt = require('codewindow.text')
 local minimap_win = require('codewindow.window')
 local minimap_hl  = require('codewindow.highlight')
 
+local defer = vim.defer_fn
+local api = vim.api
+
 function M.open_minimap()
-  local current_buffer = vim.api.nvim_get_current_buf()
+  local current_buffer = api.nvim_get_current_buf()
   local window
   window = minimap_win.create_window(current_buffer, function()
-    vim.defer_fn(M.open_minimap, 0)
+    defer(M.open_minimap, 0)
   end, function()
-    vim.defer_fn(function()
+    defer(function()
       minimap_hl.display_cursor(window)
     end, 0)
   end)
@@ -54,7 +57,7 @@ function M.setup(config)
 
   minimap_hl.setup()
 
-  vim.api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
+  api.nvim_create_autocmd({ 'BufEnter', 'WinEnter' }, {
     callback = function()
       local filetype = vim.bo.filetype
       local should_open = false
@@ -69,13 +72,13 @@ function M.setup(config)
       end
 
       if config.max_lines then
-        if vim.api.nvim_buf_line_count(vim.api.nvim_get_current_buf()) > config.max_lines then
+        if api.nvim_buf_line_count(api.nvim_get_current_buf()) > config.max_lines then
           should_open = false
         end
       end
 
       if should_open then
-        vim.defer_fn(M.open_minimap, 0)
+        defer(M.open_minimap, 0)
       end
     end
   })

--- a/lua/codewindow/errors.lua
+++ b/lua/codewindow/errors.lua
@@ -1,5 +1,8 @@
+local M = {}
+
 local utils = require 'codewindow.utils'
-local M     = {}
+
+local diagnostic = vim.diagnostic
 
 function M.get_lsp_errors(buffer)
   local lines = vim.api.nvim_buf_get_lines(buffer, 0, -1, true)
@@ -8,9 +11,9 @@ function M.get_lsp_errors(buffer)
     table.insert(error_lines, { warn = false, err = false })
   end
 
-  local errors = vim.diagnostic.get(buffer, { severity = { min = vim.diagnostic.severity.WARN } })
+  local errors = diagnostic.get(buffer, { severity = { min = diagnostic.severity.WARN } })
   for _, v in ipairs(errors) do
-    if v.severity == vim.diagnostic.severity.WARN then
+    if v.severity == diagnostic.severity.WARN then
       if v.lnum + 1 <= #error_lines then
         error_lines[v.lnum + 1].warn = true
       end

--- a/lua/codewindow/git.lua
+++ b/lua/codewindow/git.lua
@@ -1,9 +1,10 @@
 local M = {}
 
 local utils = require('codewindow.utils')
+local fn = vim.fn
 
 function M.parse_git_diff(lines)
-  local diff = vim.fn.systemlist({ 'git', 'diff', '-U0', vim.fn.expand('%') })
+  local diff = fn.systemlist({ 'git', 'diff', '-U0', fn.expand('%') })
 
   if vim.v.shell_error ~= 0 then
     return {}

--- a/lua/codewindow/highlight.lua
+++ b/lua/codewindow/highlight.lua
@@ -6,25 +6,28 @@ local underline_namespace
 local diagnostic_namespace
 local cursor_namespace
 
-function M.setup()
-  hl_namespace = vim.api.nvim_create_namespace("codewindow.highlight")
-  underline_namespace = vim.api.nvim_create_namespace("codewindow.underline")
-  diagnostic_namespace = vim.api.nvim_create_namespace("codewindow.diagnostic")
-  cursor_namespace = vim.api.nvim_create_namespace("codewindow.cursor")
+local api = vim.api
+local highlight_range = vim.highlight.range
 
-  vim.api.nvim_set_hl(0, "CodewindowBackground", { link = "Normal", default = true })
-  vim.api.nvim_set_hl(0, "CodewindowBorder", { fg = "#ffffff", default = true })
-  vim.api.nvim_set_hl(0, "CodewindowWarn", { link = "DiagnosticSignWarn", default = true })
-  vim.api.nvim_set_hl(0, "CodewindowError", { link = "DiagnosticSignError", default = true })
-  vim.api.nvim_set_hl(0, "CodewindowAddition", { fg = "#aadb56", default = true })
-  vim.api.nvim_set_hl(0, "CodewindowDeletion", { fg = "#fc4c4c", default = true })
-  vim.api.nvim_set_hl(0, "CodewindowUnderline", { underline = true, sp = "#ffffff", default = true })
+function M.setup()
+  hl_namespace = api.nvim_create_namespace("codewindow.highlight")
+  underline_namespace = api.nvim_create_namespace("codewindow.underline")
+  diagnostic_namespace = api.nvim_create_namespace("codewindow.diagnostic")
+  cursor_namespace = api.nvim_create_namespace("codewindow.cursor")
+
+  api.nvim_set_hl(0, "CodewindowBackground", { link = "Normal", default = true })
+  api.nvim_set_hl(0, "CodewindowBorder", { fg = "#ffffff", default = true })
+  api.nvim_set_hl(0, "CodewindowWarn", { link = "DiagnosticSignWarn", default = true })
+  api.nvim_set_hl(0, "CodewindowError", { link = "DiagnosticSignError", default = true })
+  api.nvim_set_hl(0, "CodewindowAddition", { fg = "#aadb56", default = true })
+  api.nvim_set_hl(0, "CodewindowDeletion", { fg = "#fc4c4c", default = true })
+  api.nvim_set_hl(0, "CodewindowUnderline", { underline = true, sp = "#ffffff", default = true })
 end
 
 local function create_hl_namespaces(buffer)
-  vim.api.nvim_buf_clear_namespace(buffer, hl_namespace, 0, -1)
-  vim.api.nvim_buf_clear_namespace(buffer, underline_namespace, 0, -1)
-  vim.api.nvim_buf_clear_namespace(buffer, diagnostic_namespace, 0, -1)
+  api.nvim_buf_clear_namespace(buffer, hl_namespace, 0, -1)
+  api.nvim_buf_clear_namespace(buffer, underline_namespace, 0, -1)
+  api.nvim_buf_clear_namespace(buffer, diagnostic_namespace, 0, -1)
 end
 
 local function most_commons(highlight)
@@ -55,7 +58,7 @@ function M.extract_highlighting(buffer, lines)
   local highlighter = require("vim.treesitter.highlighter")
   local ts_utils = require("nvim-treesitter.ts_utils")
 
-  if not vim.api.nvim_buf_is_valid(buffer) then
+  if not api.nvim_buf_is_valid(buffer) then
     return
   end
 
@@ -153,7 +156,7 @@ function M.apply_highlight(highlights, buffer, lines)
               end_x = end_x + 1
               highlights[y][x][pos] = ""
             end
-            vim.api.nvim_buf_add_highlight(buffer, hl_namespace, "@" .. group, y - 1, (x - 1) * 3 + 6, end_x * 3 + 6)
+            api.nvim_buf_add_highlight(buffer, hl_namespace, "@" .. group, y - 1, (x - 1) * 3 + 6, end_x * 3 + 6)
           end
         end
       end
@@ -161,11 +164,11 @@ function M.apply_highlight(highlights, buffer, lines)
   end
 
   for y = 1, minimap_height do
-    vim.api.nvim_buf_add_highlight(buffer, diagnostic_namespace, "CodewindowError", y - 1, 0, 3)
-    vim.api.nvim_buf_add_highlight(buffer, diagnostic_namespace, "CodewindowWarn", y - 1, 3, 6)
+    api.nvim_buf_add_highlight(buffer, diagnostic_namespace, "CodewindowError", y - 1, 0, 3)
+    api.nvim_buf_add_highlight(buffer, diagnostic_namespace, "CodewindowWarn", y - 1, 3, 6)
 
     local git_start = 6 + 3 * config.minimap_width
-    vim.highlight.range(
+    highlight_range(
       buffer,
       diagnostic_namespace,
       "CodewindowAddition",
@@ -173,7 +176,7 @@ function M.apply_highlight(highlights, buffer, lines)
       { y - 1, git_start + 3 },
       {}
     )
-    vim.highlight.range(
+    highlight_range(
       buffer,
       diagnostic_namespace,
       "CodewindowDeletion",
@@ -190,7 +193,7 @@ function M.display_screen_bounds(window)
   if underline_namespace == nil then
     return
   end
-  vim.api.nvim_buf_clear_namespace(window.buffer, underline_namespace, 0, -1)
+  api.nvim_buf_clear_namespace(window.buffer, underline_namespace, 0, -1)
 
   local topline = utils.get_top_line(window.parent_win)
   local botline = utils.get_bot_line(window.parent_win)
@@ -200,7 +203,7 @@ function M.display_screen_bounds(window)
   local top_y = math.floor(topline / 4)
 
   if top_y > 0 then
-    vim.api.nvim_buf_add_highlight(
+    api.nvim_buf_add_highlight(
       window.buffer,
       underline_namespace,
       "CodewindowUnderline",
@@ -210,14 +213,14 @@ function M.display_screen_bounds(window)
     )
   end
   local bot_y = top_y + difference - 1
-  local buf_height = vim.api.nvim_buf_line_count(window.buffer)
+  local buf_height = api.nvim_buf_line_count(window.buffer)
   if bot_y > buf_height - 1 then
     bot_y = buf_height - 1
   end
   if bot_y < 0 then
     return
   end
-  vim.api.nvim_buf_add_highlight(
+  api.nvim_buf_add_highlight(
     window.buffer,
     underline_namespace,
     "CodewindowUnderline",
@@ -227,7 +230,7 @@ function M.display_screen_bounds(window)
   )
 
   local center = math.floor((top_y + bot_y) / 2) + 1
-  vim.api.nvim_win_set_cursor(window.window, { center, 0 })
+  api.nvim_win_set_cursor(window.window, { center, 0 })
 end
 
 function M.display_cursor(window)
@@ -237,15 +240,15 @@ function M.display_cursor(window)
     return
   end
 
-  vim.api.nvim_buf_clear_namespace(window.buffer, cursor_namespace, 0, -1)
-  local cursor = vim.api.nvim_win_get_cursor(window.parent_win)
+  api.nvim_buf_clear_namespace(window.buffer, cursor_namespace, 0, -1)
+  local cursor = api.nvim_win_get_cursor(window.parent_win)
 
   local minimap_x, minimap_y = utils.buf_to_minimap(cursor[2] + 1, cursor[1])
 
   minimap_x = minimap_x + 2 - 1
   minimap_y = minimap_y - 1
 
-  vim.api.nvim_buf_add_highlight(window.buffer, cursor_namespace, "Cursor", minimap_y, minimap_x * 3, minimap_x * 3 + 3)
+  api.nvim_buf_add_highlight(window.buffer, cursor_namespace, "Cursor", minimap_y, minimap_x * 3, minimap_x * 3 + 3)
 end
 
 return M

--- a/lua/codewindow/highlight.lua
+++ b/lua/codewindow/highlight.lua
@@ -1,5 +1,9 @@
-local utils = require("codewindow.utils")
 local M = {}
+
+local config = require("codewindow.config").get()
+local utils = require("codewindow.utils")
+local highlighter
+local ts_utils
 
 local hl_namespace
 local underline_namespace
@@ -48,16 +52,7 @@ local function most_commons(highlight)
   return result
 end
 
-function M.extract_highlighting(buffer, lines)
-  local config = require("codewindow.config").get()
-
-  if not config.use_treesitter then
-    return nil
-  end
-
-  local highlighter = require("vim.treesitter.highlighter")
-  local ts_utils = require("nvim-treesitter.ts_utils")
-
+local function extract_highlighting(buffer, lines)
   if not api.nvim_buf_is_valid(buffer) then
     return
   end
@@ -126,6 +121,14 @@ function M.extract_highlighting(buffer, lines)
   return highlights
 end
 
+if config.use_treesitter then
+  highlighter = require("vim.treesitter.highlighter")
+  ts_utils = require("nvim-treesitter.ts_utils")
+  M.extract_highlighting = extract_highlighting
+else
+  M.extract_highlighting = function() end
+end
+
 local function contains_group(cell, group)
   for i, v in ipairs(cell) do
     if v == group then
@@ -136,7 +139,6 @@ local function contains_group(cell, group)
 end
 
 function M.apply_highlight(highlights, buffer, lines)
-  local config = require("codewindow.config").get()
   local minimap_height = math.ceil(#lines / 4)
   local minimap_width = config.minimap_width
 
@@ -188,8 +190,6 @@ function M.apply_highlight(highlights, buffer, lines)
 end
 
 function M.display_screen_bounds(window)
-  local config = require("codewindow.config").get()
-
   if underline_namespace == nil then
     return
   end
@@ -234,8 +234,6 @@ function M.display_screen_bounds(window)
 end
 
 function M.display_cursor(window)
-  local config = require("codewindow.config").get()
-
   if not config.show_cursor then
     return
   end

--- a/lua/codewindow/text.lua
+++ b/lua/codewindow/text.lua
@@ -1,9 +1,10 @@
+local M = {}
+
+local minimap_hl = require('codewindow.highlight')
+local minimap_err = require('codewindow.errors')
 local utils = require('codewindow.utils')
 
-local minimap_err = require('codewindow.errors')
-local minimap_hl = require('codewindow.highlight')
-
-local M = {}
+local api = vim.api
 
 local function is_whitespace(chr)
   return chr == " " or chr == "\t" or chr == ""
@@ -63,8 +64,8 @@ end
 function M.update_minimap(current_buffer, window)
   local config = require('codewindow.config').get()
 
-  vim.api.nvim_buf_set_option(window.buffer, 'modifiable', true)
-  local lines = vim.api.nvim_buf_get_lines(current_buffer, 0, -1, true)
+  api.nvim_buf_set_option(window.buffer, 'modifiable', true)
+  local lines = api.nvim_buf_get_lines(current_buffer, 0, -1, true)
 
   local minimap_text = compress_text(lines)
 
@@ -92,7 +93,7 @@ function M.update_minimap(current_buffer, window)
     text[i] = line
   end
 
-  vim.api.nvim_buf_set_lines(window.buffer, 0, -1, true, text)
+  api.nvim_buf_set_lines(window.buffer, 0, -1, true, text)
 
   local highlights = minimap_hl.extract_highlighting(current_buffer, lines)
   minimap_hl.apply_highlight(highlights, window.buffer, lines)
@@ -102,7 +103,7 @@ function M.update_minimap(current_buffer, window)
   end
 
   minimap_hl.display_screen_bounds(window)
-  vim.api.nvim_buf_set_option(window.buffer, 'modifiable', false)
+  api.nvim_buf_set_option(window.buffer, 'modifiable', false)
 end
 
 return M

--- a/lua/codewindow/utils.lua
+++ b/lua/codewindow/utils.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local get_line = vim.fn.line
+local exe = vim.cmd.execute
+local api = vim.api
+
 function M.buf_to_minimap(x, y)
   local config = require('codewindow.config').get()
   local minimap_x = math.floor((x - 1) / config.width_multiplier / 2) + 1
@@ -23,37 +27,37 @@ end
 
 function M.get_top_line(window)
   if window then
-    return vim.fn.line('w0', window)
+    return get_line('w0', window)
   end
-  return vim.fn.line('w0')
+  return get_line('w0')
 end
 
 function M.get_bot_line(window)
   if window then
-    return vim.fn.line('w$', window)
+    return get_line('w$', window)
   end
-  return vim.fn.line('w$')
+  return get_line('w$')
 end
 
 function M.get_buf_height(buffer)
-  return vim.api.nvim_buf_line_count(buffer)
+  return api.nvim_buf_line_count(buffer)
 end
 
 function M.scroll_window(window, amount)
-  if not vim.api.nvim_win_is_valid(window) then
+  if not api.nvim_win_is_valid(window) then
     return
   end
 
-  vim.api.nvim_win_call(window, function()
+  api.nvim_win_call(window, function()
     if amount > 0 then
       local botline = M.get_bot_line()
-      local buffer = vim.api.nvim_win_get_buf(window)
+      local buffer = api.nvim_win_get_buf(window)
       local height = M.get_buf_height(buffer)
       if botline >= height then
         return
       end
       local max_move_down = math.min(amount, height - botline)
-      vim.cmd(string.format('execute "normal! %d\\<C-e>"', max_move_down))
+      exe(string.format("\"normal! %d\\<C-e>\"", max_move_down))
     else
       amount = -amount
       if window == nil then
@@ -64,7 +68,7 @@ function M.scroll_window(window, amount)
         return
       end
       local max_move_up = math.min(amount, topline - 1)
-      vim.cmd(string.format('execute "normal! %d\\<C-y>"', max_move_up))
+      exe(string.format("\"normal! %d\\<C-y>\"", max_move_up))
     end
   end)
 end


### PR DESCRIPTION
This PR simply adds a couple of good practices like reducing overhead (in `treesitter`) and localizing recurrently called global vars and funcs. This probably had a performance improvement, but it's negligible.

Very clean codebase btw!

