### PR TITLE
feat: screen bounds as background

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ The setup method accepts an optional table as an argument with the following opt
   width_multiplier = 4, -- How many characters one dot represents
   z_index = 1, -- The z-index the floating window will be on
   show_cursor = true, -- Show the cursor position in the minimap
-  screen_bounds = 'lines' | 'background' -- Minimap screen bounds style
+  screen_bounds = 'lines' -- How the visible area is displayed, "lines": lines above and below, "background": background color
   window_border = 'single' -- The border style of the floating window (accepts all usual options)
-  relative = "win" -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
   relative = 'win' -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
   events = { 'TextChanged', 'InsertLeave', 'DiagnosticChanged', 'FileWritePost' } -- Events that update the code window
 }

--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ The setup method accepts an optional table as an argument with the following opt
   width_multiplier = 4, -- How many characters one dot represents
   z_index = 1, -- The z-index the floating window will be on
   show_cursor = true, -- Show the cursor position in the minimap
+  screen_bounds = 'lines' | 'background' -- Minimap screen bounds style
   window_border = 'single' -- The border style of the floating window (accepts all usual options)
   relative = "win" -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
+  relative = 'win' -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
   events = { 'TextChanged', 'InsertLeave', 'DiagnosticChanged', 'FileWritePost' } -- Events that update the code window
 }
 ```
@@ -81,6 +83,7 @@ CodewindowError -- the color of the error dots
 CodewindowAddition -- the color of the addition git sign
 CodewindowDeletion -- the color of the deletion git sign
 CodewindowUnderline -- the color of the underlines on the minimap
+CodewindowBoundsBackground -- the color of the background on the minimap
 
 -- Example
 vim.api.nvim_set_hl(0, 'CodewindowBorder', {fg = '#ffff00'})

--- a/lua/codewindow/config.lua
+++ b/lua/codewindow/config.lua
@@ -3,7 +3,7 @@ local M = {}
 local config = {
   active_in_terminals = false,
   auto_enable = false,
-  exclude_filetypes = { 'help' },
+  exclude_filetypes = { "help" },
   max_lines = nil,
   max_minimap_height = nil,
   minimap_width = 20,
@@ -13,9 +13,10 @@ local config = {
   width_multiplier = 4,
   z_index = 1,
   show_cursor = true,
-  window_border = 'single',
-  relative = 'win',
-  events = { 'TextChanged', 'InsertLeave', 'DiagnosticChanged', 'FileWritePost' }
+  screen_bounds = "lines",
+  window_border = "single",
+  relative = "win",
+  events = { "TextChanged", "InsertLeave", "DiagnosticChanged", "FileWritePost" },
 }
 
 function M.get()


### PR DESCRIPTION
Added option to set screen bounds as either lines or background and should close #46. I'm also working on a foreground version but it's actually more tricky because we need to clear hl_namespace in the current range. 
It's my first ever PR and I hope I didn't mess up formatting, you should add a quote_style rule in the stylua because quote formatting is not consistent.