### PR TITLE
feat: screen bounds as foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The setup method accepts an optional table as an argument with the following opt
   width_multiplier = 4, -- How many characters one dot represents
   z_index = 1, -- The z-index the floating window will be on
   show_cursor = true, -- Show the cursor position in the minimap
-  screen_bounds = 'lines' -- How the visible area is displayed, "lines": lines above and below, "background": background color
+  screen_bounds = 'lines' -- How the visible area is displayed, "lines": lines above and below, "background": background color, "foreground": foreground color
   window_border = 'single' -- The border style of the floating window (accepts all usual options)
   relative = 'win' -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
   events = { 'TextChanged', 'InsertLeave', 'DiagnosticChanged', 'FileWritePost' } -- Events that update the code window
@@ -83,6 +83,7 @@ CodewindowAddition -- the color of the addition git sign
 CodewindowDeletion -- the color of the deletion git sign
 CodewindowUnderline -- the color of the underlines on the minimap
 CodewindowBoundsBackground -- the color of the background on the minimap
+CodewindowBoundsForeground -- the color of the foreground on the minimap
 
 -- Example
 vim.api.nvim_set_hl(0, 'CodewindowBorder', {fg = '#ffff00'})

--- a/lua/codewindow/highlight.lua
+++ b/lua/codewindow/highlight.lua
@@ -27,6 +27,7 @@ function M.setup()
   api.nvim_set_hl(0, "CodewindowDeletion", { fg = "#fc4c4c", default = true })
   api.nvim_set_hl(0, "CodewindowUnderline", { underline = true, sp = "#ffffff", default = true })
   api.nvim_set_hl(0, "CodewindowBoundsBackground", { link = "CursorLine", default = true })
+  api.nvim_set_hl(0, "CodewindowBoundsForeground", { fg = "#aadb56", default = true })
 end
 
 local function create_hl_namespaces(buffer)
@@ -159,7 +160,11 @@ function M.apply_highlight(highlights, buffer, lines)
               end_x = end_x + 1
               highlights[y][x][pos] = ""
             end
-            api.nvim_buf_add_highlight(buffer, hl_namespace, "@" .. group, y - 1, (x - 1) * 3 + 6, end_x * 3 + 6)
+            api.nvim_buf_set_extmark(buffer, hl_namespace, y - 1, (x - 1) * 3 + 6, {
+              end_col = end_x * 3 + 6,
+              hl_group = "@" .. group,
+              priority = 100,
+            })
           end
         end
       end
@@ -247,6 +252,16 @@ function M.display_screen_bounds(window)
         6 + config.minimap_width * 3
       )
     end
+  end
+
+  if config.screen_bounds == "foreground" then
+    api.nvim_buf_set_extmark(window.buffer, screenbounds_namespace, top_y, 6, {
+      end_row = bot_y,
+      end_col = 6 + config.minimap_width * 3,
+      hl_group = "CodewindowBoundsForeground",
+      hl_eol = true,
+      priority = 200,
+    })
   end
 
   local center = math.floor((top_y + bot_y) / 2) + 1


### PR DESCRIPTION
I found a hack using extmark and it is ridiculously simple. And I found something elsen it's weird but I get different highlightings every time I open a file even with your previous implementation. I don't know if it's a parsing issue or a buffer synchronization problem but it's an actual issue. Also regarding my previous PR I just realized linking the CodewindowBoundsBackground to CursorLine was a bad idea and should set a default bg instead because not every theme has a bg with CursorLIne