### PR TITLE
Only delete buffer if buffer is valid

### DIFF
--- a/lua/codewindow/window.lua
+++ b/lua/codewindow/window.lua
@@ -60,7 +60,9 @@ end
 local augroup
 
 function M.close_minimap()
-  api.nvim_buf_delete(window.buffer, { force = true });
+  if api.nvim_buf_is_valid(window.buffer) then
+    api.nvim_buf_delete(window.buffer, { force = true });
+  end
   if augroup then
     api.nvim_clear_autocmds({ group = augroup })
   end


### PR DESCRIPTION
On quitting nvim close_minimap is called and this triggers lots of "invalid buffer" error messages, when this code tries to delete the minimap window buffer. At least in my setup this happens.

So I added a check to test if the buffer is valid before deleting it.