### PR TITLE
Set minimap height relative to editor when 'relative=editor' is configured

### DIFF
--- a/lua/codewindow/window.lua
+++ b/lua/codewindow/window.lua
@@ -69,6 +69,11 @@ function M.close_minimap()
   window = nil
 end
 
+local function get_editor_height()
+  local editor_height = vim.o.lines - vim.o.cmdheight - vim.o.laststatus
+  return editor_height
+end
+
 local function get_window_height(current_window)
   local window_height = vim.fn.winheight(current_window)
   return window_height
@@ -76,6 +81,9 @@ end
 
 local function get_window_config(current_window)
   local minimap_height = get_window_height(current_window)
+  if config.relative == "editor" then
+    minimap_height = get_editor_height()
+  end
   if config.max_minimap_height then
     minimap_height = math.min(minimap_height, config.max_minimap_height)
   end


### PR DESCRIPTION
If the `rel="editor"` setting is used the minimap should take up the whole editor height rather than resizing to a window.

I'm using these settings:

```lua
codewindow.setup({
	relative = "editor",
	minimap_width = 10,
})
```

## Old Behavior
In this image, the minimap only displays in the top window:
<img width="1470" alt="before" src="https://github.com/gorbit99/codewindow.nvim/assets/498643/d29b9c8e-64c0-4ac7-b3c8-a4d23620e78a">

## New Behavior
With these changes, the minimap window will be sized in relation to the editor rather than the current window:
<img width="1470" alt="after" src="https://github.com/gorbit99/codewindow.nvim/assets/498643/819f9b00-07f8-4a0e-ad73-2ae44b5b6061">

Note that this still respects the `max_minimap_height` setting.

Btw, thanks for your work on this plugin. I previously used minimap.vim but am moving to this due to the nice lsp and treesitter integrations.