### PR TITLE
Fix config example errors and add lazyvim packager example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ use {
 }
 ```
 
+Lazy:
+```lua
+{
+  'gorbit99/codewindow.nvim',
+  init = function() 
+    require('codewindow').apply_default_keybinds()
+  end,
+  opts = {
+    -- here you can paste configuration block
+  },
+}
+```
+
 ## Configuration
 
 The setup method accepts an optional table as an argument with the following options (with the defaults):

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ The setup method accepts an optional table as an argument with the following opt
   width_multiplier = 4, -- How many characters one dot represents
   z_index = 1, -- The z-index the floating window will be on
   show_cursor = true, -- Show the cursor position in the minimap
-  screen_bounds = 'lines' -- How the visible area is displayed, "lines": lines above and below, "background": background color
-  window_border = 'single' -- The border style of the floating window (accepts all usual options)
-  relative = 'win' -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
-  events = { 'TextChanged', 'InsertLeave', 'DiagnosticChanged', 'FileWritePost' } -- Events that update the code window
+  screen_bounds = 'lines', -- How the visible area is displayed, "lines": lines above and below, "background": background color
+  window_border = 'single', -- The border style of the floating window (accepts all usual options)
+  relative = 'win', -- What will be the minimap be placed relative to, "win": the current window, "editor": the entire editor
+  events = { 'TextChanged', 'InsertLeave', 'DiagnosticChanged', 'FileWritePost' }, -- Events that update the code window
 }
 ```
 config changes get merged in with defaults, so defining every config option is unnecessary (and probably error prone).


### PR DESCRIPTION
The config example is missing few `,` and as I was already there - added Lazy packager installation instructions :P