### PR TITLE
use vim.hl over vim.highlight

### DIFF
--- a/lua/codewindow/highlight.lua
+++ b/lua/codewindow/highlight.lua
@@ -11,7 +11,7 @@ local diagnostic_namespace
 local cursor_namespace
 
 local api = vim.api
-local highlight_range = vim.highlight.range
+local highlight_range = vim.hl.range
 
 function M.setup()
   hl_namespace = api.nvim_create_namespace("codewindow.highlight")


### PR DESCRIPTION
This change fixed a deprecation warning from `:checkhealth vim.deprecated` where we were using `vim.highlight` (which is now deprecated) in favor of `vim.hl`.